### PR TITLE
fix username bug and avatar_url bug

### DIFF
--- a/flog/templates/user/user_profile.html
+++ b/flog/templates/user/user_profile.html
@@ -67,9 +67,11 @@
                 {{ _("Edit Profile [Admin]") }}
             </a>
         {% endif %}
-        <a class="btn btn-outline-primary" href="{{ url_for('group.invite_user', user_id=user.id) }}">
-            {{ _("Invite this user to your group.") }}
-        </a>
+        {% if not current_user == user %}
+            <a class="btn btn-outline-primary" href="{{ url_for('group.invite_user', user_id=user.id) }}">
+                {{ _("Invite this user to your group.") }}
+            </a>
+        {% endif %}
     </div>
 </div>
 {% endblock page_content %}

--- a/flog/user/forms.py
+++ b/flog/user/forms.py
@@ -28,7 +28,7 @@ class EditProfileForm(FlaskForm):
         validators=[
             Length(0, 32),
             Regexp(
-                r"^([A-Za-z][A-Za-z0-9_\-.])*$",
+                r"^[A-Za-z]([A-Za-z0-9_\-.])*$",
                 0,
                 _l(
                     "Usernames must have only letters, numbers, dots, underscores or dashes"

--- a/flog/user/views.py
+++ b/flog/user/views.py
@@ -40,6 +40,7 @@ def edit_profile():
     form.name.data = current_user.name
     form.location.data = current_user.location
     form.about_me.data = current_user.about_me
+    form.custom_avatar_url.data = current_user.custom_avatar_url
     return render_template("user/edit_profile.html", form=form)
 
 


### PR DESCRIPTION
我懒得用template了，直接和你讲吧。
事情是这样的。你的正则表达式长这样：
```
^([A-Za-z][A-Za-z0-9_\-.])*$
```
但是这就有一个问题了。username必须符合这些条件：
+ 字符数为偶数。也就是说，`lithium`和`boron`不行就是因为这个。
+ 奇数位不能用数字和标点符号。也就是说，`rice0208`和`RSGC2-18`是不合法的。因为第5、第7个位置不是字母。

修改后，亲测有效

## Checklist

- [x] Run `sh scripts/test.sh`, no tests failed.

If you changed the html templates or css/js, you must:
- [ ] Paste screenshots.

If you changed the Python code, you must:
- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.

**另附：这个bug我上周和你说过了。请您高抬贵手给我加21个币（我在抢劫吗？！）**
